### PR TITLE
Managing Tech Debt: Legacy-compatible Filtering of Annotations by IIIF Canvas

### DIFF
--- a/src/SupabasePlugin.ts
+++ b/src/SupabasePlugin.ts
@@ -30,12 +30,14 @@ export const SupabasePlugin = (anno: Annotator<SupabaseAnnotation, SupabaseAnnot
 
   // Set up channel and connectors for each channel type
   let channel: RealtimeChannel = null;
-  
-  const presence = PresenceConnector(anno, config.appearanceProvider, emitter, config.source);
 
-  const broadcast = BroadcastConnector(anno, defaultLayerId, presence, config.source);
+  const sourceId = typeof config.source === 'string' ? config.source : config.source.uri;
   
-  const postgres = PostgresConnector(anno, defaultLayerId, config.layerIds, supabase, presence, emitter, config.source, config.canvases);
+  const presence = PresenceConnector(anno, config.appearanceProvider, emitter, sourceId);
+
+  const broadcast = BroadcastConnector(anno, defaultLayerId, presence, sourceId);
+  
+  const postgres = PostgresConnector(anno, defaultLayerId, config.layerIds, supabase, presence, emitter, config.source);
 
   // Creates the channel and inits all connectors
   const init = () => {

--- a/src/SupabasePluginConfig.ts
+++ b/src/SupabasePluginConfig.ts
@@ -15,10 +15,7 @@ export type SupabasePluginConfig = {
 
   layerIds: string | string[],
   
-  source?: string;
-
-  // @deprecated
-  canvases?: Canvas[];
+  source?: string | Canvas;
 
   supabaseUrl: string,
   

--- a/src/postgres/pgConnector.ts
+++ b/src/postgres/pgConnector.ts
@@ -15,8 +15,7 @@ export const PostgresConnector = (
   supabase: SupabaseClient, 
   presence: ReturnType<typeof PresenceConnector>, 
   emitter: Emitter<SupabasePluginEvents>,
-  source?: string,
-  canvases?: Canvas[]
+  source?: string | Canvas
 ) => {
 
   let privacyMode = false;
@@ -26,7 +25,7 @@ export const PostgresConnector = (
   let receiver: ReturnType<typeof createReceiver> | undefined;
 
   const connect = (channel: RealtimeChannel) => {
-    sender = createSender(anno, defaultLayerId, layerIds, supabase, emitter, source, canvases);
+    sender = createSender(anno, defaultLayerId, layerIds, supabase, emitter, source);
     sender.privacyMode = privacyMode;
 
     receiver = createReceiver(anno, layerIds, channel, presence, emitter, source);

--- a/src/postgres/receiver/pgReceiver.ts
+++ b/src/postgres/receiver/pgReceiver.ts
@@ -1,5 +1,6 @@
 import { type Annotator, Origin } from '@annotorious/core';
 import type { RealtimeChannel, RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+import type { Canvas } from '@allmaps/iiif-parser';
 import type { Emitter } from 'nanoevents';
 import type { SupabaseAnnotation } from '../../SupabaseAnnotation';
 import type { PresenceConnector } from '../../presence';
@@ -13,7 +14,7 @@ export const createReceiver = (
   channel: RealtimeChannel, 
   presence: ReturnType<typeof PresenceConnector>, 
   emitter: Emitter<SupabasePluginEvents>,
-  source?: string
+  source?: string | Canvas
 ) => {
 
   const { store } = anno.state;
@@ -96,8 +97,10 @@ export const createReceiver = (
       // from the Supabase event.
       // See https://github.com/performant-software/vico/issues/351
       if (target.creator?.id === anno.getUser().id) return;
-  
-      const shouldInsert = !source || target.selector['source'] === source;
+
+      const sourceURI = source ? typeof source === 'string' ? source : source.uri : undefined;
+      const shouldInsert = !source || target.selector['source'] === sourceURI;
+
       if (shouldInsert) {
         store.addAnnotation({
           id: annotation_id,

--- a/src/postgres/sender/pgOps.ts
+++ b/src/postgres/sender/pgOps.ts
@@ -18,6 +18,8 @@ export const pgOps = (
 
   const { store } = anno.state;
 
+  const sourceURI = typeof source === 'string' ? source : source.uri;
+
   // Generic Supabase retry handler
   const withRetry = async (requestFn: () => PostgrestBuilder<{ [x: string]: any}[]>, retries: number = 3) => {
     return new Promise<PostgrestSingleResponse<{ [x: string]: any}[]>>((resolve, reject) => {
@@ -111,7 +113,7 @@ export const pgOps = (
     };
 
     if (source)
-      versioned.target.selector['source'] = typeof source === 'string' ? source : source.uri;
+      versioned.target.selector['source'] = sourceURI;
 
     store.updateAnnotation(versioned, Origin.REMOTE);
     
@@ -129,7 +131,7 @@ export const pgOps = (
   const createTarget = (t: AnnotationTarget, layer_id: string) => {
     const selector = source ? {
       ...t.selector,
-      source: typeof source === 'string' ? source : source.uri
+      source: sourceURI
     } : t.selector;
 
     return supabase
@@ -216,7 +218,7 @@ export const pgOps = (
       };
 
       if (source)
-        versioned.selector['source'] = typeof source === 'string' ?  source : source.uri;
+        versioned.selector['source'] = sourceURI;
 
       store.updateTarget(versioned, Origin.REMOTE);
 

--- a/src/postgres/sender/pgOps.ts
+++ b/src/postgres/sender/pgOps.ts
@@ -1,4 +1,5 @@
 import { Origin } from '@annotorious/core';
+import type { Canvas } from '@allmaps/iiif-parser';
 import type { Annotation, AnnotationBody, Annotator, AnnotationTarget } from '@annotorious/core';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { PostgrestBuilder, PostgrestSingleResponse } from '@supabase/postgrest-js';
@@ -12,7 +13,7 @@ import {
 export const pgOps = (
   anno: Annotator<Annotation, Annotation>, 
   supabase: SupabaseClient,
-  source?: string
+  source?: string | Canvas
 ) => {
 
   const { store } = anno.state;
@@ -110,7 +111,7 @@ export const pgOps = (
     };
 
     if (source)
-      versioned.target.selector['source'] = source;
+      versioned.target.selector['source'] = typeof source === 'string' ? source : source.uri;
 
     store.updateAnnotation(versioned, Origin.REMOTE);
     
@@ -128,7 +129,7 @@ export const pgOps = (
   const createTarget = (t: AnnotationTarget, layer_id: string) => {
     const selector = source ? {
       ...t.selector,
-      source
+      source: typeof source === 'string' ? source : source.uri
     } : t.selector;
 
     return supabase
@@ -215,7 +216,7 @@ export const pgOps = (
       };
 
       if (source)
-        versioned.selector['source'] = source;
+        versioned.selector['source'] = typeof source === 'string' ?  source : source.uri;
 
       store.updateTarget(versioned, Origin.REMOTE);
 


### PR DESCRIPTION
## In this PR

**The problem:** in the current version of Recogito Studio (1.4), we've been using the wrong `source` identifier to associate image annotations with their target IIIF canvas. Instead of the Canvas URI (as required by the standard), we had been using the _URL of the image service associated with the canvas_. This created the following problems:

- **We were not able to serialize IIIF image annotations to Web Annotation format properly.** Our `source` property was wrong, and without the original manifest, it is not possible to infer the actual `source` from the image service URL.
- **Exporting a derivative IIIF manifest requires a hack.** When exporting a copy of the original manifest merged with our own annotations, we would have to find and replace the wrong `source` IDs to generate a proper manifest.

I have fixed the handling of `source` in Recogito Studio. **However:** this introduces a breaking change! Annotations generated with Recogito v1.4 would no longer display in Recogito Studio 1.5+!

This PR introduces a legacy-compatible solution:
- New annotations will get stored with the proper canvas URI as the `source` parameter.
- The code that filters annotations by canvas supports both conventions.
- Pre-requisite: when initializing the SupabasePlugin, the `Canvas` must be passed as the `source` init parameter.

```ts
export type SupabasePluginConfig = {

  appearanceProvider?: AppearanceProvider

  apiKey: string,

  channel: string,

  defaultLayer?: string,

  eventsPerSecond?: number,

  layerIds: string | string[],
  
  // When initializing, this must be a Canvas–otherwise the
  // legacy mechanism won't be able to resolve outdated
  // source values in the annotation
  source?: string | Canvas;

  supabaseUrl: string,
  
}
```